### PR TITLE
[Feat] withdraw 회원 탈퇴 

### DIFF
--- a/src/main/java/com/pleiades/controller/AuthController.java
+++ b/src/main/java/com/pleiades/controller/AuthController.java
@@ -2,6 +2,9 @@ package com.pleiades.controller;
 
 import com.pleiades.dto.UserInfoDto;
 import com.pleiades.entity.*;
+import com.pleiades.exception.CustomException;
+import com.pleiades.exception.ErrorCode;
+import com.pleiades.exception.CustomException;
 import com.pleiades.model.TokenValidateResult;
 import com.pleiades.repository.*;
 import com.pleiades.service.auth.AuthService;
@@ -18,7 +21,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
@@ -107,6 +109,16 @@ public class AuthController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("message","unvalid refresh token"));
         }
         authService.logout(email);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Map<String, Object>> withdraw(HttpServletRequest request, @CookieValue("refreshToken") String refreshToken) {
+        log.info("/auth/withdraw");
+        String email = (String) request.getAttribute("email");
+        if(email == null) { throw new CustomException(ErrorCode.INVALID_TOKEN);}
+        authService.withdraw(email);
 
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/src/main/java/com/pleiades/entity/Report.java
+++ b/src/main/java/com/pleiades/entity/Report.java
@@ -22,7 +22,7 @@ public class Report {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = true)
     @OnDelete(action = OnDeleteAction.CASCADE)
     User user;
 

--- a/src/main/java/com/pleiades/repository/FriendRepository.java
+++ b/src/main/java/com/pleiades/repository/FriendRepository.java
@@ -42,4 +42,6 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     // 보낸 친구 요청 목록
     List<Friend> findBySenderAndStatus(User sender, FriendStatus status);
+
+    void deleteAllBySenderOrReceiver(User sender, User receiver);
 }

--- a/src/main/java/com/pleiades/repository/KakaoTokenRepository.java
+++ b/src/main/java/com/pleiades/repository/KakaoTokenRepository.java
@@ -1,6 +1,7 @@
 package com.pleiades.repository;
 
 import com.pleiades.entity.KakaoToken;
+import com.pleiades.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,5 @@ import java.util.Optional;
 public interface KakaoTokenRepository extends JpaRepository<KakaoToken, Long> {
     Optional<KakaoToken> findByUser_Id(String userId);
     Optional<KakaoToken> findByEmail(String email);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/pleiades/repository/NaverTokenRepository.java
+++ b/src/main/java/com/pleiades/repository/NaverTokenRepository.java
@@ -14,5 +14,6 @@ public interface NaverTokenRepository extends JpaRepository<NaverToken, Long> {
 
     Optional<NaverToken> findByRefreshToken(String refreshToken);
     Optional<NaverToken> findByEmail(String email);
+    void deleteByUser(User user);
 }
 

--- a/src/main/java/com/pleiades/repository/ReportHistoryRepository.java
+++ b/src/main/java/com/pleiades/repository/ReportHistoryRepository.java
@@ -15,4 +15,5 @@ public interface ReportHistoryRepository extends JpaRepository<ReportHistory, Lo
     List<ReportHistory> findByUserOrderByCreatedAtDesc(User user);
     Optional<ReportHistory> findById(Long id);
     Optional<ReportHistory> findByQuery(String query);
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/pleiades/repository/ReportRepository.java
+++ b/src/main/java/com/pleiades/repository/ReportRepository.java
@@ -4,6 +4,9 @@ import com.pleiades.entity.Question;
 import com.pleiades.entity.Report;
 import com.pleiades.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,4 +19,10 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     List<Report> findByUser(User user);
     List<Report> findByUserOrderByCreatedAtDesc(User user);
     List<Report> findByUserOrderByCreatedAtAsc(User user);
+
+    // 탈퇴할 때 user 비식별 처리
+    @Modifying
+    @Query("UPDATE Report r SET r.user = null WHERE r.user = :user")
+    void anonymizeUserFromReports(@Param("user") User user);
+
 }

--- a/src/main/java/com/pleiades/repository/SignalRepository.java
+++ b/src/main/java/com/pleiades/repository/SignalRepository.java
@@ -12,4 +12,6 @@ public interface SignalRepository extends JpaRepository<Signal, Long> {
     List<Signal> findByReceiver(User receiver);
     boolean existsBySenderAndReceiver(User sender, User receiver);
     void deleteBySenderAndReceiver(User sender, User receiver);
+    void deleteAllBySender(User sender);
+    void deleteAllByReceiver(User receiver);
 }

--- a/src/main/java/com/pleiades/repository/StarRepository.java
+++ b/src/main/java/com/pleiades/repository/StarRepository.java
@@ -1,6 +1,7 @@
 package com.pleiades.repository;
 
 import com.pleiades.entity.Star;
+import com.pleiades.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,5 @@ import java.util.Optional;
 @Repository
 public interface StarRepository extends JpaRepository<Star, Long> {
     Optional<Star> findByUserId(String userId);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/pleiades/repository/UserHistoryRepository.java
+++ b/src/main/java/com/pleiades/repository/UserHistoryRepository.java
@@ -18,4 +18,6 @@ public interface UserHistoryRepository extends JpaRepository<UserHistory, Long> 
 
     // 검색 기록이 존재 하는 지 확인
     Optional<UserHistory> findByCurrentAndSearched(User current, User searched);
+
+    void deleteAllByCurrent(User user);
 }

--- a/src/main/java/com/pleiades/repository/UserStationRepository.java
+++ b/src/main/java/com/pleiades/repository/UserStationRepository.java
@@ -1,5 +1,6 @@
 package com.pleiades.repository;
 
+import com.pleiades.entity.Station;
 import com.pleiades.entity.StationReport;
 import com.pleiades.entity.User;
 import com.pleiades.entity.User_Station.UserStation;
@@ -33,4 +34,9 @@ public interface UserStationRepository extends JpaRepository<UserStation, UserSt
 
     @Query("SELECT sr FROM UserStation sr WHERE sr.station.id = :stationId AND sr.user.id = :userId")
     Optional<UserStation> findByStationIdAndUserId(@Param("stationId") String stationId, @Param("userId") String userId);
+
+    @Query("SELECT us.station FROM UserStation us WHERE us.user = :user AND us.isAdmin = true")
+    List<Station> findStationsWhereUserIsAdmin(@Param("user") User user);
+
+    void deleteAllByUser(User user);
 }


### PR DESCRIPTION
### 🌠 관련 이슈
- closed #17 

### 🌠 주요 변경 사항
- AuthController, AuthService에 withdraw 관련 메소드 추가
- user랑 mapping된 모든 entity(repository)에 delete 관련 코드 추가

### 🌠 기타 작업
- 탈퇴 시 report의 user 정보만 비식별로 만드는 기능 추가
- 탈퇴하는 user가 방장일 시 station 폭파 기능 추가

### 🌠 미구현된 내용
- 추후 상점 도입 시 사용자가 구매한 보유 아이템, 중고 아이템 삭제 관련 기획 필요