### PR TITLE
feat: official store 검색 기능 추가

### DIFF
--- a/src/main/java/com/pleiades/controller/OfficialStoreController.java
+++ b/src/main/java/com/pleiades/controller/OfficialStoreController.java
@@ -142,4 +142,20 @@ public class OfficialStoreController {
         Long ownershipId = officialStoreService.buyItem(user.getId(), itemIdDto.getItemId());
         return ResponseEntity.status(HttpStatus.OK).body(PurchaseResponseDto.successOf(ownershipId));
     }
+
+    @Operation(summary = "공식몰 검색", description = "공식몰 아이템 검색")
+    @GetMapping
+    public ResponseEntity<OfficialStoreDto> searchOfficialStore(
+            HttpServletRequest request,
+            @RequestParam(required = false) String query
+    ) {
+        String email = (String) request.getAttribute("email");
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        OfficialStoreDto dto = officialStoreService.searchOfficialStore(query, user.getId());
+
+        return ResponseEntity.ok(dto);
+    }
+
 }

--- a/src/main/java/com/pleiades/repository/character/TheItemRepository.java
+++ b/src/main/java/com/pleiades/repository/character/TheItemRepository.java
@@ -23,4 +23,22 @@ public interface TheItemRepository extends JpaRepository<TheItem, Long> {
     Optional<TheItem> findByTypeAndName(ItemType type, String name);
 
     Optional<TheItem> findByName(String itemName);
+
+    // store 내 검색 query
+    @Query("""
+select distinct i
+from TheItem i
+left join i.itemThemes it
+left join it.theme t
+left join i.itemKeywords ik
+left join ik.keyword k
+where
+    (:query is null or :query = '' or
+     lower(i.name) like lower(concat('%', :query, '%'))
+     or lower(i.description) like lower(concat('%', :query, '%'))
+     or lower(t.name) like lower(concat('%', :query, '%'))
+     or lower(k.name) like lower(concat('%', :query, '%'))
+    )
+""")
+    List<TheItem> searchOfficialItems(@Param("query") String query);
 }

--- a/src/main/java/com/pleiades/repository/store/OfficialWishlistRepository.java
+++ b/src/main/java/com/pleiades/repository/store/OfficialWishlistRepository.java
@@ -14,10 +14,21 @@ import java.util.Optional;
 @Repository
 public interface OfficialWishlistRepository extends JpaRepository<OfficialWishlist, Long> {
 
+    // user ID, type (TOP, BOTTOM, SET ...) 으로 찾기
+    // TheItemRepository: item 찾을 때 type 으로 찾아야 함
     @Query("SELECT i FROM OfficialWishlist i WHERE i.item.type IN :types AND i.user.id=:userid")
     List<OfficialWishlist> findByTypesInWishlist(@Param("types") List<ItemType> types, @Param("userid") String userid);
 
     Optional<OfficialWishlist> findByUserIdAndItemId(String userId, Long itemId);
 
     boolean existsByUserIdAndItemId(String userId, Long itemId);
+
+    // store 내 검색 query
+    @Query("""
+select ow.item.id
+from OfficialWishlist ow
+where ow.user.id = :userId
+""")
+    List<Long> findAllWishlistItemIds(@Param("userId") String userId);
+
 }

--- a/src/main/java/com/pleiades/service/store/OfficialStoreService.java
+++ b/src/main/java/com/pleiades/service/store/OfficialStoreService.java
@@ -1,6 +1,7 @@
 package com.pleiades.service.store;
 
 import com.pleiades.dto.store.OfficialItemDto;
+import com.pleiades.dto.store.OfficialStoreDto;
 import com.pleiades.entity.User;
 import com.pleiades.entity.character.TheItem;
 import com.pleiades.entity.store.OfficialWishlist;
@@ -133,4 +134,20 @@ public class OfficialStoreService {
 
         return newOwnership.getId();
     }
+
+    // Official Item&Store Dto, itemToOfficialItemDto 기존꺼 재사용함
+    @Transactional
+    public OfficialStoreDto searchOfficialStore(String query, String userId) {
+
+        List<TheItem> items = itemRepository.searchOfficialItems(query);
+
+        List<OfficialItemDto> dtos = items.stream()
+                .map(this::itemToOfficialItemDto)
+                .toList();
+
+        List<Long> wishlist = officialWishlistRepository.findAllWishlistItemIds(userId);
+
+        return new OfficialStoreDto(dtos, wishlist);
+    }
+
 }


### PR DESCRIPTION
### 🌠 관련 이슈
- #93 

### 🌠 주요 변경 사항
- TheItemRepository query 추가
- OfficialWishlistRepository query 추가 
- OfficialStoreService, Controller 로직 추가 

### 🌠 기타 작업
- Official Item&Store Dto, itemToOfficialItemDto 재사용

### 🌠 미구현된 내용
- resale store 검색