### PR TITLE
fix: Redis health check 비활성화

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,5 +34,6 @@ spring.security.oauth2.client.registration.kakao.client-authentication-method=PO
 management.endpoint.health.show-details=always
 management.health.db.enabled=true
 management.health.diskspace.enabled
+management.health.redis.enabled=false
 
 logging.pattern.dateformat=yyyy-MM-dd HH:mm:ss.SSS,Asia/Seoul


### PR DESCRIPTION
## Summary
- Redis 연결 실패 시 `/actuator/health`가 `DOWN`을 반환해 main 브랜치 배포 health check가 실패하는 문제 수정
- `management.health.redis.enabled=false` 추가로 Redis 상태를 health check에서 제외

## Test plan
- [ ] main 브랜치 배포 시 health check 통과 확인
- [ ] Redis 연결 실패 상태에서도 앱 정상 기동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)